### PR TITLE
ADT chunk holes are 16-bit

### DIFF
--- a/src/lib/adt/index.js
+++ b/src/lib/adt/index.js
@@ -128,7 +128,8 @@ const MCNK = Chunk({
   sizeMCSH: r.uint32le,
   areaID: r.uint32le,
   wmoCount: r.uint32le,
-  holes: r.uint32le,
+  holes: r.uint16le,
+  unknown: r.uint16le,
 
   textureMaps: new r.Reserved(r.uint16le, 8),
 


### PR DESCRIPTION
Small adjustment here to the low resolution version of map tile chunk holes.

We're currently decoding this as a 32-bit 'bitmap', but is in fact only 16-bit (4x4 grid) as [documented on Wowdev](https://wowdev.wiki/ADT/v18#MCNK_chunk) and also in line with [our usage in Wowser](https://github.com/wowserhq/wowser/blob/master/src/lib/pipeline/adt/chunk/index.js#L102-L108).