### PR TITLE
Normalize MCAL instantiation

### DIFF
--- a/src/lib/adt/index.js
+++ b/src/lib/adt/index.js
@@ -153,7 +153,7 @@ const MCNK = Chunk({
   MCSH: new r.Optional(MCSH, function() {
     return this.flags & 0x01;
   }),
-  MCAL: new MCAL(),
+  MCAL: MCAL,
   MCLQ: new r.Optional(MCLQ, function() {
     return this.offsetMCLQ;
   }),

--- a/src/lib/adt/mcal.js
+++ b/src/lib/adt/mcal.js
@@ -88,4 +88,4 @@ class MCAL {
 
 }
 
-export default MCAL;
+export default new MCAL();


### PR DESCRIPTION
MCAL does not require any arguments on instantiation nor does it keep state. Dropping usage of the `new` operator brings it in line with the rest of the chunks.